### PR TITLE
Layout file(仮置き)を追加しました

### DIFF
--- a/WhiteboardFormatter/app/build.gradle
+++ b/WhiteboardFormatter/app/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.firebase:firebase-analytics:17.2.0'
+    implementation 'com.google.firebase:firebase-analytics:17.2.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
@@ -69,8 +69,8 @@ dependencies {
     kapt "com.android.databinding:compiler:$android_plugin_version"
 
     // Kotlin
-    implementation "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
-    implementation "androidx.fragment:fragment-testing:$fragmentVersion"
+    implementation "androidx.fragment:fragment-ktx:1.2.0-rc04"
+    implementation "androidx.fragment:fragment-testing:1.2.0-rc04"
     implementation "androidx.test:core:$androidXTestCoreVersion"
     implementation "androidx.fragment:fragment:$fragmentVersion"
 }

--- a/WhiteboardFormatter/app/src/main/AndroidManifest.xml
+++ b/WhiteboardFormatter/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:screenOrientation="landscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/ViewModelFactory.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/ViewModelFactory.kt
@@ -1,0 +1,40 @@
+//package com.example.whiteboardformatter
+//
+//import androidx.lifecycle.ViewModel
+//import androidx.lifecycle.ViewModelProvider
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.data.repository.DishRepository
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.data.repository.FoodStuffRepository
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.dish.DishesViewModel
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.dish.addEditDish.AddEditDishViewModel
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.dish.detailDish.DetailDishViewModel
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.foodstaff.FoodStuffViewModel
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.foodstaff.addEditFoodStuff.AddEditFoodStuffViewModel
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.foodstaff.detailFoodStuff.DetailFoodStuffViewModel
+//import java.lang.IllegalArgumentException
+//
+//@Suppress("UNCHECKED_CAST")
+//class ViewModelFactory (
+//    private val foodStuffRepository: FoodStuffRepository,
+//    private val dishRepository: DishRepository
+//):ViewModelProvider.NewInstanceFactory(){
+//
+//    override fun <T: ViewModel> create(modelClass: Class<T>)=
+//        with(modelClass){
+//            when{
+//                isAssignableFrom(FoodStuffViewModel::class.java)->
+//                    FoodStuffViewModel(foodStuffRepository)
+//                isAssignableFrom(AddEditFoodStuffViewModel::class.java)->
+//                    AddEditFoodStuffViewModel(foodStuffRepository)
+//                isAssignableFrom(DetailFoodStuffViewModel::class.java)->
+//                    DetailFoodStuffViewModel(foodStuffRepository)
+//                isAssignableFrom(DishesViewModel::class.java)->
+//                    DishesViewModel(dishRepository)
+//                isAssignableFrom(AddEditDishViewModel::class.java)->
+//                    AddEditDishViewModel(dishRepository)
+//                isAssignableFrom(DetailDishViewModel::class.java)->
+//                    DetailDishViewModel(dishRepository)
+//                else->
+//                    throw IllegalArgumentException("Unknown ViewModelclass ${modelClass}")
+//            }
+//        }  as T
+//}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/edit_page/EditFragment.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/edit_page/EditFragment.kt
@@ -1,0 +1,7 @@
+package com.example.whiteboardformatter.edit_page
+
+import androidx.fragment.app.Fragment
+
+class EditFragment:Fragment(){
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/edit_page/EditViewModel.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/edit_page/EditViewModel.kt
@@ -1,0 +1,7 @@
+package com.example.whiteboardformatter.edit_page
+
+import androidx.lifecycle.ViewModel
+
+class EditViewModel ():ViewModel(){
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/list_page/ListFragment.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/list_page/ListFragment.kt
@@ -1,0 +1,7 @@
+package com.example.whiteboardformatter.list_page
+
+import androidx.fragment.app.Fragment
+
+class ListFragment : Fragment(){
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/list_page/ListViewModel.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/list_page/ListViewModel.kt
@@ -1,0 +1,7 @@
+package com.example.whiteboardformatter.list_page
+
+import androidx.lifecycle.ViewModel
+
+class ListViewModel ():ViewModel(){
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/save_page/SaveFragment.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/save_page/SaveFragment.kt
@@ -1,0 +1,7 @@
+package com.example.whiteboardformatter.save_page
+
+import androidx.fragment.app.Fragment
+
+class SaveFragment :Fragment(){
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/save_page/SaveViewModel.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/save_page/SaveViewModel.kt
@@ -1,0 +1,7 @@
+package com.example.whiteboardformatter.save_page
+
+import androidx.lifecycle.ViewModel
+
+class SaveViewModel ():ViewModel(){
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/EventObserver.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/EventObserver.kt
@@ -1,0 +1,26 @@
+package com.example.whiteboardformatter.util
+
+
+import androidx.lifecycle.Observer
+
+class Event<out T>(private val context:T){
+    var hasHandled = false
+        private set
+    fun getContextIfNotHandled():T?{
+        return if(hasHandled){
+            null
+        }else{
+            hasHandled=true
+            context
+        }
+    }
+}
+
+class EventObserver<T>(private val onEventUnhandledContext:(T)->Unit) : Observer<Event<T>>{
+    override fun onChanged(event: Event<T>?){
+        event?.getContextIfNotHandled()?.let{
+            onEventUnhandledContext(it)
+        }
+    }
+
+}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/FragmentExtension.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/FragmentExtension.kt
@@ -1,0 +1,15 @@
+//package com.example.whiteboardformatter.util
+//
+//import androidx.fragment.app.Fragment
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.ViewModelFactory
+//
+//fun Fragment.getViewModelFactory(): ViewModelFactory {
+////    val app = requireContext().applicationContext
+////    val health = app as HealthManagementApp
+////    val foodStuffRepository = health.foodStuffRepository
+//    val foodStuffRepository =
+//        ServiceLoader.provideFoodStuffRepository(requireContext())
+//    val dishRepository=
+//        ServiceLoader.provideDishRepository(requireContext())
+//    return ViewModelFactory(foodStuffRepository,dishRepository)
+//}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/ServiceLoader.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/ServiceLoader.kt
@@ -1,0 +1,59 @@
+//package com.example.whiteboardformatter.util
+//
+//import android.content.Context
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.data.HealthDatabase
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.data.repository.DishRepository
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.data.repository.FoodStuffRepository
+//import kotlinx.coroutines.CoroutineScope
+//import kotlinx.coroutines.Dispatchers
+//import kotlinx.coroutines.Job
+//
+//object ServiceLoader {
+//    private var database : HealthDatabase? = null
+//    var foodStuffRepository:FoodStuffRepository? = null
+//    var dishRepository:DishRepository?=null
+//
+//    fun provideFoodStuffRepository(context: Context):FoodStuffRepository{
+//        synchronized(this) {
+//            return foodStuffRepository
+//                ?: createFoodStuffRepository(
+//                    context
+//                )
+//        }
+//    }
+//
+//    fun provideDishRepository(context:Context):DishRepository{
+//        synchronized(this){
+//            return dishRepository
+//                ?: createDishRepository(
+//                    context
+//                )
+//        }
+//    }
+//
+//    private fun createFoodStuffRepository(context:Context):FoodStuffRepository{
+//        val database = database
+//            ?: createDatabase(
+//                context
+//            )
+//        val result = FoodStuffRepository(database.foodStuffDao())
+//        foodStuffRepository = result
+//        return result
+//    }
+//
+//    private fun createDishRepository(context:Context):DishRepository{
+//        val database = database
+//            ?: createDatabase(
+//                context
+//            )
+//        val result = DishRepository(database.dishDao())
+//        dishRepository = result
+//        return result
+//    }
+//
+//    private fun createDatabase(context:Context):HealthDatabase{
+//        val result = HealthDatabase.getDatabase(context)
+//        database =result
+//        return result
+//    }
+//}

--- a/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/WhiteboardFormatter.kt
+++ b/WhiteboardFormatter/app/src/main/java/com/example/whiteboardformatter/util/WhiteboardFormatter.kt
@@ -1,0 +1,36 @@
+package com.example.whiteboardformatter.util
+
+//import android.app.Application
+//import android.content.Context
+//import com.amebaownd.pikohan_nwiatori.healthmanagementapp.data.repository.FoodStuffRepository
+//import java.lang.RuntimeException
+//
+//class HealthManagementApp : Application() {
+//    val repository: FoodStuffRepository
+//        get() = ServiceLoader.provideFoodStuffRepository(
+//            this
+//        )
+//    override fun onCreate() {
+//        super.onCreate()
+//        MyContext.onCreateAppcalition(this)
+//    }
+//}
+//
+//class MyContext(application :Context){
+//    var applicationContext = application
+//    companion object{
+//        private lateinit var instance:MyContext
+//        fun onCreateAppcalition(applicationContext:Context){
+//            instance = MyContext(applicationContext)
+//        }
+//        fun getContext():Context{
+//            if(instance.applicationContext==null)
+//                throw RuntimeException()
+//            return instance.applicationContext
+//        }
+//        fun getString(resId:Int):String{
+//            return instance.applicationContext.getString(resId)
+//        }
+//
+//    }
+//}

--- a/WhiteboardFormatter/app/src/main/res/drawable/camera_white.xml
+++ b/WhiteboardFormatter/app/src/main/res/drawable/camera_white.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path android:fillColor="#FF000000" android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/WhiteboardFormatter/app/src/main/res/drawable/check_white.xml
+++ b/WhiteboardFormatter/app/src/main/res/drawable/check_white.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/WhiteboardFormatter/app/src/main/res/drawable/delete_red.xml
+++ b/WhiteboardFormatter/app/src/main/res/drawable/delete_red.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FF0000"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/WhiteboardFormatter/app/src/main/res/drawable/done_white.xml
+++ b/WhiteboardFormatter/app/src/main/res/drawable/done_white.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18,7l-1.41,-1.41 -6.34,6.34 1.41,1.41L18,7zM22.24,5.59L11.66,16.17 7.48,12l-1.41,1.41L11.66,19l12,-12 -1.42,-1.41zM0.41,13.41L6,19l1.41,-1.41L1.83,12 0.41,13.41z"/>
+</vector>

--- a/WhiteboardFormatter/app/src/main/res/drawable/edit_gray.xml
+++ b/WhiteboardFormatter/app/src/main/res/drawable/edit_gray.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#636363"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/WhiteboardFormatter/app/src/main/res/layout/fragment_edit.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/fragment_edit.xml
@@ -6,6 +6,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/edit_parent_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/WhiteboardFormatter/app/src/main/res/layout/fragment_edit.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/fragment_edit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/edit_confirm_fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+
+            android:layout_marginBottom="16dp"
+            android:clickable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/check_white" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/WhiteboardFormatter/app/src/main/res/layout/fragment_list.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/fragment_list.xml
@@ -26,7 +26,7 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
+            app:layout_constraintEnd_toStartOf="@+id/list_guideline"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -34,21 +34,23 @@
             tools:listitem="@layout/item_list" />
 
         <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline2"
+            android:id="@+id/list_guideline"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             app:layout_constraintGuide_percent="0.6" />
 
         <ScrollView
+            android:id="@+id/list_preview_scrollview"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/guideline2"
+            app:layout_constraintStart_toStartOf="@+id/list_guideline"
             app:layout_constraintTop_toTopOf="parent">
 
             <LinearLayout
+                android:id="@+id/list_preview_linearlayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical" />

--- a/WhiteboardFormatter/app/src/main/res/layout/fragment_list.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/fragment_list.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/list_move_to_camera_fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:clickable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/camera_white" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/list_textlist_recyclerview"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/guideline2"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
+            tools:listitem="@layout/item_list" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.6" />
+
+        <ScrollView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/guideline2"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+        </ScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/WhiteboardFormatter/app/src/main/res/layout/fragment_save.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/fragment_save.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <Button
+            android:id="@+id/button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="share"
+            app:layout_constraintBottom_toTopOf="@+id/floatingActionButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/guideline" />
+
+        <Button
+            android:id="@+id/button2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="Copy"
+            app:layout_constraintBottom_toTopOf="@+id/button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/guideline" />
+
+        <ScrollView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/guideline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+        </ScrollView>
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.75" />
+
+        <Button
+            android:id="@+id/button3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Back to Cam"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/guideline"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Switch
+            android:id="@+id/switch1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            app:layout_constraintBottom_toTopOf="@+id/button2"
+            app:layout_constraintEnd_toEndOf="@+id/button2"
+            app:layout_constraintStart_toStartOf="@+id/button2" />
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toTopOf="@+id/switch1"
+            app:layout_constraintEnd_toEndOf="@+id/switch1"
+            app:layout_constraintStart_toStartOf="@+id/switch1"
+            tools:text="mdファイル" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/floatingActionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:clickable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/done_white" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/WhiteboardFormatter/app/src/main/res/layout/fragment_save.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/fragment_save.xml
@@ -11,77 +11,79 @@
         android:layout_height="match_parent">
 
         <Button
-            android:id="@+id/button"
+            android:id="@+id/save_share_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
             android:text="share"
-            app:layout_constraintBottom_toTopOf="@+id/floatingActionButton"
+            app:layout_constraintBottom_toTopOf="@+id/save_confirm_fab"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/guideline" />
+            app:layout_constraintStart_toStartOf="@+id/save_gridline" />
 
         <Button
-            android:id="@+id/button2"
+            android:id="@+id/save_copy_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
             android:text="Copy"
-            app:layout_constraintBottom_toTopOf="@+id/button"
+            app:layout_constraintBottom_toTopOf="@+id/save_share_button"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/guideline" />
+            app:layout_constraintStart_toStartOf="@+id/save_gridline" />
 
         <ScrollView
+            android:id="@+id/save_preview_scrollview"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/guideline"
+            app:layout_constraintEnd_toStartOf="@+id/save_gridline"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
             <LinearLayout
+                android:id="@+id/save_preview_linearlayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical" />
         </ScrollView>
 
         <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline"
+            android:id="@+id/save_gridline"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             app:layout_constraintGuide_percent="0.75" />
 
         <Button
-            android:id="@+id/button3"
+            android:id="@+id/save_back_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="Back to Cam"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/guideline"
+            app:layout_constraintStart_toStartOf="@+id/save_gridline"
             app:layout_constraintTop_toTopOf="parent" />
 
         <Switch
-            android:id="@+id/switch1"
+            android:id="@+id/save_file_type_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
-            app:layout_constraintBottom_toTopOf="@+id/button2"
-            app:layout_constraintEnd_toEndOf="@+id/button2"
-            app:layout_constraintStart_toStartOf="@+id/button2" />
+            app:layout_constraintBottom_toTopOf="@+id/save_copy_button"
+            app:layout_constraintEnd_toEndOf="@+id/save_copy_button"
+            app:layout_constraintStart_toStartOf="@+id/save_copy_button" />
 
         <TextView
-            android:id="@+id/textView"
+            android:id="@+id/save_file_type_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
-            app:layout_constraintBottom_toTopOf="@+id/switch1"
-            app:layout_constraintEnd_toEndOf="@+id/switch1"
-            app:layout_constraintStart_toStartOf="@+id/switch1"
+            app:layout_constraintBottom_toTopOf="@+id/save_file_type_switch"
+            app:layout_constraintEnd_toEndOf="@+id/save_file_type_switch"
+            app:layout_constraintStart_toStartOf="@+id/save_file_type_switch"
             tools:text="mdファイル" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/floatingActionButton"
+            android:id="@+id/save_confirm_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"

--- a/WhiteboardFormatter/app/src/main/res/layout/item_list.xml
+++ b/WhiteboardFormatter/app/src/main/res/layout/item_list.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_back_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/item_title_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="アイデア出し" />
+
+        <TextView
+            android:id="@+id/item_timestump_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toStartOf="@+id/item_edit_imagebutton"
+            app:layout_constraintTop_toTopOf="@+id/item_title_textview"
+            tools:text="2019/12/28 13:00" />
+
+        <ImageButton
+            android:id="@+id/item_delete_imagebutton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/colorAlpha"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/item_edit_imagebutton"
+            app:srcCompat="@drawable/delete_red" />
+
+        <ImageButton
+            android:id="@+id/item_edit_imagebutton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/colorAlpha"
+            app:layout_constraintBottom_toBottomOf="@+id/item_timestump_textview"
+            app:layout_constraintEnd_toStartOf="@+id/item_delete_imagebutton"
+            app:layout_constraintTop_toTopOf="@+id/item_timestump_textview"
+            app:srcCompat="@drawable/edit_gray" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/WhiteboardFormatter/app/src/main/res/values/colors.xml
+++ b/WhiteboardFormatter/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
+    <color name="colorAlpha">#00000000</color>
 </resources>

--- a/WhiteboardFormatter/build.gradle
+++ b/WhiteboardFormatter/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
-        classpath 'com.google.gms:google-services:4.3.2'
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 
@@ -28,11 +28,11 @@ task clean(type: Delete) {
 }
 
 ext {
-    roomVersion = '2.1.0-alpha07'
-    archLifecycleVersion = '2.2.0-alpha01'
+    roomVersion = '2.2.3'
+    archLifecycleVersion = '2.2.0-rc03'
     androidxArchVersion = '2.0.0'
     coroutines = '1.2.0'
-    fragmentVersion = '1.1.0-alpha07'
+    fragmentVersion = '1.2.0-rc04'
     fragmentKtxVersion = '1.1.0-rc01'
     androidXTestCoreVersion = '1.2.0'
 }


### PR DESCRIPTION
## 概要
　List画面、Save画面、Edit画面、Listのitemのレイアウトを追加しました。

## 画像
List画面(item)
<img src="https://user-images.githubusercontent.com/29095003/71542315-3b0a5980-29a8-11ea-9018-aebb6428f21a.png" width="50%">
Edit画面
<img src="https://user-images.githubusercontent.com/29095003/71542318-45c4ee80-29a8-11ea-9fd1-22cf4c5f5296.png" width="50%">
Save画面
<img src="https://user-images.githubusercontent.com/29095003/71542319-478eb200-29a8-11ea-8ff2-1293bf99c86a.png" width="50%">
## 詳細
##### List画面
- 画面の左側がrecyclerViewでリストを表示し、右側で選択されたitemのプレビューが確認できる形になっています。
- listの編集、削除ボタンが冗長なので、スワイプすると出現するような形にするか、fabの隣にボタンを置くなどの形にしたほうがいいかも。
- 右下のfabをタップすると、カメラを起動して画面遷移する形になるかと。
##### Edit画面
- constraintLayoutをバックにFabを配置してあります。
- fabをタップすると、Save画面に移行します。
- constraintLayoutに画像から生成したTextViewを乗っける感じです。
##### Save画面
- 左側がプレビュー画面、右側が各種メニューになっています。
- backtocamボタンを押すとカメラへインテントを飛ばし直す
- switchを押すと、出力するファイルをtxt,mdで切り替えられます。switchの上にあるtextviewはswitchの切り替えで変更されます。この方式にしましたが、switchが２つの状態しかないので新しいファイル形式にしたいときは拡張性ないです。それについてもコメント願いたし。
- copyボタンは、タップするとtxtデータをクリップボードにコピーします。mdファイルが選択されているとタップできないようになるかと思います。
- sharebuttonはタップするとgmailにインテントを飛ばして、ファイルを添付します。
- fabをタップするとリスト画面へ遷移します。おそらくこのボタンをタップした後に、保存するか否かのポップアップを出す形になると思います。
## 備考
- レイアウトについて細かい話し合いをしていないので、私の想像で作った部分が多いためコメントをよろしくお願いします。